### PR TITLE
Fix facilmap not working properly with Postgres

### DIFF
--- a/server/src/database/helpers.ts
+++ b/server/src/database/helpers.ts
@@ -252,6 +252,7 @@ export default class DatabaseHelpers {
 				condition.include = [ ...(condition.include ? (Array.isArray(condition.include) ? condition.include : [ condition.include ]) : [ ]), this._db._conn.model(type + "Data") ];
 			}
 
+
 			const Pad = this._db.pads.PadModel.build({ id: padId } satisfies Partial<CreationAttributes<PadModel>> as any);
 			const objs: Array<Model> = await (Pad as any)["get" + this._db._conn.model(type).getTableName()](condition);
 

--- a/server/src/database/helpers.ts
+++ b/server/src/database/helpers.ts
@@ -370,7 +370,7 @@ export default class DatabaseHelpers {
 	}
 
 	makeBboxCondition(bbox: BboxWithExcept | null | undefined, posField = "pos"): WhereOptions {
-		const dbType  = this._db._conn.options.dialect
+		const dbType  = this._db._conn.getDialect()
 		if(!bbox)
 			return { };
 

--- a/server/src/database/helpers.ts
+++ b/server/src/database/helpers.ts
@@ -113,34 +113,6 @@ export interface BboxWithExcept extends Bbox {
 	except?: Bbox;
 }
 
-export function makeBboxCondition(bbox: BboxWithExcept | null | undefined, posField = "pos"): WhereOptions {
-	if(!bbox)
-		return { };
-
-	const conditions = [ ];
-	conditions.push(
-		Sequelize.fn(
-			"MBRContains",
-			Sequelize.fn("LINESTRING", Sequelize.fn("POINT", bbox.left, bbox.bottom), Sequelize.fn("POINT", bbox.right, bbox.top)),
-			Sequelize.col(posField)
-		)
-	);
-
-	if(bbox.except) {
-		conditions.push({
-			[Op.not]: Sequelize.fn(
-				"MBRContains",
-				Sequelize.fn("LINESTRING", Sequelize.fn("POINT", bbox.except.left, bbox.except.bottom), Sequelize.fn("POINT", bbox.except.right, bbox.except.top)),
-				Sequelize.col(posField)
-			)
-		});
-	}
-
-	return {
-		[Op.and]: conditions
-	};
-}
-
 export default class DatabaseHelpers {
 
 	_db: Database;
@@ -395,6 +367,54 @@ export default class DatabaseHelpers {
 
 		await model.destroy({ where: idObj});
 		await model.bulkCreate(this._dataToArr(data, idObj));
+	}
+
+	makeBboxCondition(bbox: BboxWithExcept | null | undefined, posField = "pos"): WhereOptions {
+		const dbType  = this._db._conn.options.dialect
+		if(!bbox)
+			return { };
+
+		const conditions = [ ];
+		if(dbType == 'postgres') {
+			conditions.push(
+				Sequelize.where(
+					Sequelize.fn("ST_MakeLine", Sequelize.fn("St_Point", bbox.left, bbox.bottom), Sequelize.fn("St_Point", bbox.right, bbox.top)), 
+					"~",
+					 Sequelize.col(posField))
+			);
+		} else {
+			conditions.push(
+				Sequelize.fn(
+					"MBRContains",
+					Sequelize.fn("LINESTRING", Sequelize.fn("POINT", bbox.left, bbox.bottom), Sequelize.fn("POINT", bbox.right, bbox.top)),
+					Sequelize.col(posField)
+				)
+			);
+		}
+
+		if(bbox.except) {
+			if(dbType == 'postgres') {
+				conditions.push({
+					[Op.not]: Sequelize.where(
+							Sequelize.fn("St_MakeLine", Sequelize.fn("St_Point", bbox.except.left, bbox.except.bottom), Sequelize.fn("St_Point", bbox.except.right, bbox.except.top)),
+							"~",
+							Sequelize.col(posField)
+					)
+				});
+			} else {
+				conditions.push({
+					[Op.not]: Sequelize.fn(
+							"MBRContains",
+							Sequelize.fn("LINESTRING", Sequelize.fn("POINT", bbox.except.left, bbox.except.bottom), Sequelize.fn("POINT", bbox.except.right, bbox.except.top)),
+							Sequelize.col(posField)
+					)
+				});
+			}
+		}
+
+		return {
+			[Op.and]: conditions
+		};
 	}
 
 	renameObjectDataField(padId: PadId, typeId: ID, rename: Record<string, { name?: string; values?: Record<string, string> }>, isLine: boolean): Promise<void> {

--- a/server/src/database/line.ts
+++ b/server/src/database/line.ts
@@ -1,7 +1,7 @@
 import { CreationAttributes, CreationOptional, DataTypes, ForeignKey, HasManyGetAssociationsMixin, InferAttributes, InferCreationAttributes, Model, Op } from "sequelize";
 import { BboxWithZoom, ID, Latitude, Line, LineCreate, ExtraInfo, LineUpdate, Longitude, PadId, Point, Route, TrackPoint } from "facilmap-types";
 import Database from "./database";
-import { BboxWithExcept, createModel, dataDefinition, DataModel, getDefaultIdType, getLatType, getLonType, getPosType, getVirtualLatType, getVirtualLonType, makeBboxCondition, makeNotNullForeignKey, validateColour } from "./helpers";
+import { BboxWithExcept, createModel, dataDefinition, DataModel, getDefaultIdType, getLatType, getLonType, getPosType, getVirtualLatType, getVirtualLonType, makeNotNullForeignKey, validateColour } from "./helpers";
 import { groupBy, isEqual, mapValues, omit } from "lodash";
 import { wrapAsync } from "../utils/streams";
 import { calculateRouteForLine } from "../routing/routing";
@@ -279,7 +279,7 @@ export default class DatabaseLines {
 								zoom: { [Op.lte]: bboxWithZoom.zoom },
 								lineId: { [Op.in]: lineIds }
 							},
-							makeBboxCondition(bboxWithZoom)
+							this._db.helpers.makeBboxCondition(bboxWithZoom)
 						]
 					},
 					attributes: ["pos", "lat", "lon", "ele", "zoom", "idx", "lineId"]

--- a/server/src/database/marker.ts
+++ b/server/src/database/marker.ts
@@ -1,6 +1,6 @@
 import { CreationOptional, DataTypes, ForeignKey, InferAttributes, InferCreationAttributes, Model } from "sequelize";
 import { BboxWithZoom, ID, Latitude, Longitude, Marker, MarkerCreate, MarkerUpdate, PadId } from "facilmap-types";
-import { BboxWithExcept, createModel, dataDefinition, DataModel, getDefaultIdType, getPosType, getVirtualLatType, getVirtualLonType, makeBboxCondition, makeNotNullForeignKey, validateColour } from "./helpers";
+import { BboxWithExcept, createModel, dataDefinition, DataModel, getDefaultIdType, getPosType, getVirtualLatType, getVirtualLonType, makeNotNullForeignKey, validateColour } from "./helpers";
 import Database from "./database";
 import { getElevationForPoint } from "../elevation";
 import { PadModel } from "./pad";
@@ -69,7 +69,7 @@ export default class DatabaseMarkers {
 	}
 
 	getPadMarkers(padId: PadId, bbox?: BboxWithZoom & BboxWithExcept): Highland.Stream<Marker> {
-		return this._db.helpers._getPadObjects<Marker>("Marker", padId, { where: makeBboxCondition(bbox) });
+		return this._db.helpers._getPadObjects<Marker>("Marker", padId, { where: this._db.helpers.makeBboxCondition(bbox) });
 	}
 
 	getPadMarkersByType(padId: PadId, typeId: ID): Highland.Stream<Marker> {

--- a/server/src/database/route.ts
+++ b/server/src/database/route.ts
@@ -2,7 +2,7 @@ import { generateRandomId } from "../utils/utils";
 import { DataTypes, InferAttributes, InferCreationAttributes, Model, Op, WhereOptions } from "sequelize";
 import Database from "./database";
 import { BboxWithZoom, ID, Latitude, Longitude, PadId, Point, Route, RouteMode, TrackPoint } from "facilmap-types";
-import { BboxWithExcept, createModel, getPosType, getVirtualLatType, getVirtualLonType, makeBboxCondition } from "./helpers";
+import { BboxWithExcept, createModel, getPosType, getVirtualLatType, getVirtualLonType } from "./helpers";
 import { calculateRouteForLine } from "../routing/routing";
 import { omit } from "lodash";
 import { Point as GeoJsonPoint } from "geojson";
@@ -56,7 +56,7 @@ export default class DatabaseRoutes {
 			routeId,
 			...(!bboxWithZoom ? {} : {
 				[Op.or]: [
-					{ [Op.and]: [ makeBboxCondition(bboxWithZoom), { zoom: { [Op.lte]: bboxWithZoom.zoom } } ] },
+					{ [Op.and]: [ this._db.helpers.makeBboxCondition(bboxWithZoom), { zoom: { [Op.lte]: bboxWithZoom.zoom } } ] },
 					...(!getCompleteBasicRoute ? [] : [
 						{ zoom: { [Op.lte]: 5 } }
 					])


### PR DESCRIPTION
Hello,
looks like Facilmap is not working properly with Postgres due to the use of MariaDB specific functions in makeBboxCondition.

**Expected behaviour**
On a Facilmap instance configured to use Postgres i create a new map and start to add Markers and Lines.
Then I reload the map and i expect to see all my Markers and Lines.

**Actual behaviour**
When I reload the map i see just the Lines, not the Markers, and get this error:
```
SequelizeDatabaseError: function linestring(point, point) does not exist
    at Query.formatError (/tmp/facilmap/node_modules/sequelize/lib/dialects/postgres/query.js:386:16)
    at Query.run (/tmp/facilmap/node_modules/sequelize/lib/dialects/postgres/query.js:87:18)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at /tmp/facilmap/node_modules/sequelize/lib/sequelize.js:619:16
    at PostgresQueryInterface.select (/tmp/facilmap/node_modules/sequelize/lib/dialects/abstract/query-interface.js:938:12)
    at Function.findAll (/tmp/facilmap/node_modules/sequelize/lib/model.js:1753:21)
    at HasMany.get (/tmp/facilmap/node_modules/sequelize/lib/associations/has-many.js:228:21)
    at /tmp/facilmap/server/src/database/helpers.ts:269:31

```
**Proposed fix**
makeBboxCondition is moved into DatabaseHelpers so it's possible to access the Sequelize object and check if the dialect it's "postgres" if it is Postgres specific code is executed.

The fix has been (quickly) tested both on Postgres and MariaDB (to be done on Spatialite)

P.S. Facilmap is amazing, thank you for your work!